### PR TITLE
Allow users to specify any version of node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM heroku/cedar:14
 # Internally, we arbitrarily use port 3000
 ENV PORT 3000
 # Which version of node?
-ENV NODE_ENGINE 0.12.2
+ARG NODE_ENGINE=0.12.2
+ENV NODE_ENGINE ${NODE_ENGINE}
 # Locate our binaries
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH
 


### PR DESCRIPTION
Disclaimer: I've not tried using the ARG command in a base image and can not find any docs which say if it will work or not.

This PR adds the ability for a user to pass a custom node version to the dockerfile.

This is achieved via the ARG command. An example build command would be:
`docker build . --build-arg NODE_VERSION=5.2.0`