### PR TITLE
Set NODE_ENGINE to latest LTS v4.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM heroku/cedar:14
 # Internally, we arbitrarily use port 3000
 ENV PORT 3000
 # Which version of node?
-ENV NODE_ENGINE 0.12.2
+ENV NODE_ENGINE 4.3.0
 # Locate our binaries
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH
 


### PR DESCRIPTION
I'm creating a pull request to `master`, but I think the better will be to maintain a separate branch for 4.3.x.
