### PR TITLE
Update to latest stable Node and verify binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 5.6.0
+ENV NODE_ENGINE 5.10.0
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,21 @@ ENV NODE_ENGINE 5.6.0
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH
 
+# Add gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
 # Create Node installation directory
 RUN mkdir -p /app/heroku/node
 
@@ -18,6 +33,13 @@ WORKDIR /app/user
 
 # Install Node
 RUN curl -s https://nodejs.org/dist/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.gz | tar --strip-components=1 -xz -C /app/heroku/node
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_ENGINE/SHASUMS256.txt.asc" \
+  && gpg --verify SHASUMS256.txt.asc \
+  && grep " node-v$NODE_ENGINE-linux-x64.tar.xz\$" SHASUMS256.txt.asc | sha256sum -c - \
+  && tar -xJf "node-v$NODE_ENGINE-linux-x64.tar.xz" -C /app/heroku/node --strip-components=1 \
+  && rm "node-v$NODE_ENGINE-linux-x64.tar.xz" SHASUMS256.txt.asc
 
 # Make the PATH available to Heroku by export to .profile.d
 RUN echo "export PATH=\"/app/heroku/node/bin:/app/user/node_modules/.bin:\$PATH\"" > /app/.profile.d/nodejs.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 5.10.1
+ENV NODE_ENGINE 6.2.2
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 5.4.0
+ENV NODE_ENGINE 5.4.1
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 5.5.0
+ENV NODE_ENGINE 5.6.0
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 5.4.1
+ENV NODE_ENGINE 5.5.0
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH
 # Create Node installation directory
 RUN mkdir -p /app/heroku/node
 
-# Create Heroky setup directory
+# Create Heroku setup directory
 RUN mkdir -p /app/.profile.d
 
 # Change to working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN mkdir -p /app/.profile.d
 WORKDIR /app/user
 
 # Install Node
-RUN curl -s https://nodejs.org/dist/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.gz | tar --strip-components=1 -xz -C /app/heroku/node
-
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_ENGINE/SHASUMS256.txt.asc" \
   && gpg --verify SHASUMS256.txt.asc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 4.1.2
+ENV NODE_ENGINE 5.4.0
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,23 @@
-# Inherit from Heroku's stack
+# Inherit Heroku OS
 FROM heroku/cedar:14
 
-# Internally, we arbitrarily use port 3000
-ENV PORT 3000
-# Which version of node?
-ENV NODE_ENGINE 0.12.2
-# Locate our binaries
+# Set Node Version
+ENV NODE_ENGINE 4.1.2
+
+# Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH
 
-# Create some needed directories
-RUN mkdir -p /app/heroku/node /app/.profile.d
+# Create Node installation directory
+RUN mkdir -p /app/heroku/node
+
+# Create Heroky setup directory
+RUN mkdir -p /app/.profile.d
+
+# Change to working directory
 WORKDIR /app/user
 
-# Install node
-RUN curl -s https://s3pository.heroku.com/node/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.gz | tar --strip-components=1 -xz -C /app/heroku/node
+# Install Node
+RUN curl -s https://nodejs.org/dist/v$NODE_ENGINE/node-v$NODE_ENGINE-linux-x64.tar.gz | tar --strip-components=1 -xz -C /app/heroku/node
 
-# Export the node path in .profile.d
+# Make the PATH available to Heroku by export to .profile.d
 RUN echo "export PATH=\"/app/heroku/node/bin:/app/user/node_modules/.bin:\$PATH\"" > /app/.profile.d/nodejs.sh
-
-ONBUILD ADD package.json /app/user/
-ONBUILD RUN /app/heroku/node/bin/npm install
-ONBUILD ADD . /app/user/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 This image is for use with the [Heroku Docker CLI plugin](https://github.com/heroku/heroku-docker).
 
+Public auto builds for this variant can be found at https://hub.docker.com/r/binarytales/heroku-nodejs/
+
+The repository for this variant can found at https://github.com/Binarytales/heroku-nodejs
+
+# Changes from heroku/docker-nodejs
+
+https://github.com/heroku/docker-nodejs
+
+- Binaries are now verified in the same manner as they are in the official Docker Node builds
+https://github.com/nodejs/node#verifying-binaries
+https://github.com/nodejs/docker-node
+
+- This version removes the `ONBUILD` commands so you will need to set up your Dockerfile accordingly (see 'Usage')
+TODO: I plan on adding `:onbuild` variants in the same way the official Docker Node project does  
+
+# Dockerhub settings
+
+The Dockerhub build is set to auto build when both branches and tags are pushed to the Github repository.
+
+In this way the `lts` and `latest` tags point to the latest LTS and Stable Node versions and then specific
+versions are available as version number tags
+
+It is also set to rebuild when the parent image at https://hub.docker.com/r/heroku/cedar/ is rebuilt.
+This hasn't happened yet and so I'm not totally sure exactly which builds get rebuilt (all versions, just latest)?
+
+
+## Usage
+
+The Dockerfile in your project should look something like this for basic usage
+
+```
+FROM FROM binarytales/heroku-nodejs:5.6.0
+
+ADD package.json /app/user/
+RUN /app/heroku/node/bin/npm install
+ADD . /app/user/
+```
+
+## From original README
+
 ## Usage
 
 Your project must contain the following files:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Public auto builds for this variant can be found at https://hub.docker.com/r/bin
 
 The repository for this variant can found at https://github.com/Binarytales/heroku-nodejs
 
-# Changes from heroku/docker-nodejs
+## Changes from heroku/docker-nodejs
 
 https://github.com/heroku/docker-nodejs
 
@@ -17,9 +17,9 @@ https://github.com/nodejs/docker-node
 - This version removes the `ONBUILD` commands so you will need to set up your Dockerfile accordingly (see 'Usage')
 TODO: I plan on adding `:onbuild` variants in the same way the official Docker Node project does  
 
-# Dockerhub settings
+## Docker Hub settings
 
-The Dockerhub build is set to auto build when both branches and tags are pushed to the Github repository.
+The Docker Hub build is set to auto build when both branches and tags are pushed to the Github repository.
 
 In this way the `lts` and `latest` tags point to the latest LTS and Stable Node versions and then specific
 versions are available as version number tags
@@ -40,7 +40,7 @@ RUN /app/heroku/node/bin/npm install
 ADD . /app/user/
 ```
 
-## From original README
+#Original README
 
 ## Usage
 


### PR DESCRIPTION
This pull request updates the Node version to the latest stable release. It also verifies the Node binaries in the same way that the official Node Docker builds do (https://github.com/nodejs/docker-node/blob/0c722500f66fb5f606a57824babe9798ae98667b/5.6/Dockerfile)

This pull request is taken from a project that drives public automated builds on Docker Hub for latest stable and LTS releases as well as specific version numbers. I have raised an issues detailing this which other may find useful. https://github.com/heroku/docker-nodejs/issues/5
